### PR TITLE
Feature pagination

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -12,7 +12,7 @@ Faker==2.0.1
 Flask==1.1.1
 Flask-Marshmallow==0.10.1
 Flask-Migrate==2.5.2
-flask_monitoringdashboard
+flask_monitoringdashboard==3.0.6
 flask-redis==0.4.0
 Flask-RESTful==0.3.7
 Flask-Script==2.0.6
@@ -28,6 +28,7 @@ Marshmallow-SQLAlchemy==0.19.0
 Mako==1.1.0
 MarkupSafe==1.1.1
 more-itertools==7.2.0
+numpy
 packaging==19.1
 pluggy==0.12.0
 psutil==5.6.3

--- a/src/artifice/__init__.py
+++ b/src/artifice/__init__.py
@@ -1,2 +1,2 @@
 name = "Artifice"
-__version__ = "1.5.2"
+__version__ = "1.5.3"

--- a/src/artifice/scraper/core/commands.py
+++ b/src/artifice/scraper/core/commands.py
@@ -4,13 +4,16 @@ import subprocess
 from flask_script import Command
 
 
-def get_package_name():
-    import inspect
-    try:
-        pkg = inspect.getmodule(inspect.stack()[1][0]).__name__
-        return pkg.split('.')[0]
-    except AttributeError as err:
-        raise AttributeError('{0}\nFunction must be called from within another module to return a valid result'.format(str(err)))
+# def get_package_name():
+#     """
+#     In this case, should just return `artifice`
+#     """
+#     import inspect
+#     try:
+#         pkg = inspect.getmodule(inspect.stack()[1][0]).__name__
+#         return pkg.split('.')[0]
+#     except AttributeError as err:
+#         raise AttributeError('{0}\nFunction must be called from within another module to return a valid result'.format(str(err)))
 
 
 class PytestCommand(Command):
@@ -30,6 +33,7 @@ class CoverageCommand(Command):
     capture_all_args = False
 
     def __call__(self, app=None):
-        pkg_name = get_package_name()
+        # pkg_name = get_package_name()
+        pkg_name = 'artifice'
         cmd = 'py.test --cov-report term-missing --cov {0}'.format(pkg_name)
         subprocess.call(cmd, shell=True)

--- a/src/artifice/scraper/resources/content.py
+++ b/src/artifice/scraper/resources/content.py
@@ -15,7 +15,7 @@ from artifice.scraper.utils import (
 from artifice.scraper.schemas import (
     content_schema,
     contents_schema,
-    args_schema,
+    pagination_schema,
 )
 
 log = logging.getLogger(__name__)
@@ -30,9 +30,9 @@ class ContentResource(Resource):
         '''
         if _id:
             return self.get_one(_id)
-        args, _ = args_schema.dump(request.get_json())
-        result = db.session.query(Content).limit( \
-                    args.get('limit')).all()
+        args, _ = pagination_schema.dump(request.args)
+        result = db.session.query(Content).filter(Content.id.between(
+                    args['begins'], args['ends'])).all()
         data, _ = contents_schema.dump(result)
         return reply_success(msg=args, reply=data)
 

--- a/src/artifice/scraper/schemas/__init__.py
+++ b/src/artifice/scraper/schemas/__init__.py
@@ -1,4 +1,4 @@
-from .base import ma, BaseArgSchema
+from .base import ma, BaseArgSchema, PaginationSchema
 from .args import QueueArgsSchema
 from .status import StatusSchema
 from .queue import QueueSchema
@@ -13,3 +13,4 @@ content_schema       = ContentSchema()
 contents_schema      = ContentSchema(many=True)
 args_schema          = BaseArgSchema()
 queue_args_schema    = QueueArgsSchema()
+pagination_schema    = PaginationSchema()

--- a/src/artifice/scraper/schemas/base.py
+++ b/src/artifice/scraper/schemas/base.py
@@ -1,6 +1,6 @@
 from flask import current_app
 from flask_marshmallow import Marshmallow
-from marshmallow import Schema, fields
+from marshmallow import Schema, fields, post_dump
 
 import artifice.scraper.config.constants as constants
 
@@ -15,3 +15,27 @@ class BaseSchema(ma.ModelSchema):
 
 class BaseArgSchema(Schema):
     limit = fields.Int(required=False, default=constants.ARGS_DEFAULT_LIMIT)
+
+
+class PaginationSchema(Schema):
+    """
+    Used to control the index and amount of `content` resources shown
+    by means of request arguments. This allows pagination without the
+    need for a JSON request body, allowing control from a web browser.
+
+    Schema enforces the following rules, in order:
+        - If no ``begins`` arg is provided, value defaults to 1
+        - If no ``ends`` arg is provided, value defaults to 10
+        - If ``begins`` is greater than ``ends``, values are switched
+    """
+    begins = fields.Int(required=False, strict=False, default=1)
+    ends = fields.Int(required=False, strict=False, default=10)
+
+    @post_dump
+    def _post_dump(self, data, **kwargs):
+        """ Correct improperly-ordered params """
+        if data["begins"] > data["ends"]:
+            tmp = data["ends"]
+            data["ends"] = data["begins"]
+            data["begins"] = tmp
+        return data

--- a/tests/test_api_content.py
+++ b/tests/test_api_content.py
@@ -41,3 +41,19 @@ def test_get_returns_specific_content(client, session):
     response = client.get(endpoint + '/1')
 
     assert response.status_code == 200
+
+
+def test_get_returns_pagination_content(client, session):
+    # provide valid args
+    urlencoding = '?begins=9&ends=11'
+    response = client.get(endpoint+urlencoding)
+    assert response.status_code == 200
+    assert response.json.get('msg')['begins'] == 9
+    assert response.json.get('msg')['ends'] == 11
+
+    # provide reversed arguments
+    urlencoding = '?begins=11&ends=9'
+    response = client.get(endpoint+urlencoding)
+    assert response.status_code == 200
+    assert response.json.get('msg')['begins'] == 9
+    assert response.json.get('msg')['ends'] == 11

--- a/tests/test_core_util.py
+++ b/tests/test_core_util.py
@@ -1,8 +1,8 @@
 import pytest
 
 
-def test_core_get_package_name():
-    from artifice.scraper.core.commands import get_package_name
-    name = get_package_name()
-
-    assert name in ('artifice', 'tests')
+# def test_core_get_package_name():
+#     from artifice.scraper.core.commands import get_package_name
+#     name = get_package_name()
+#
+#     assert name in ('artifice', 'tests')


### PR DESCRIPTION
Added the ability to control pagination for the `/content` endpoint. Parameters are specified using url encoded keys `begins` & `ends`.

For example, to view entries with id [12:34] you would use `/content?begins=12&ends=34`

In the case that `begins` is a greater value than `ends`, the values are automatically swapped.

The actual values that are used as part of the SQL query will always be returned in the `msg` key of the response.
